### PR TITLE
fix typo in language files for FE-Module

### DIFF
--- a/contao/languages/de/default.xlf
+++ b/contao/languages/de/default.xlf
@@ -10,11 +10,11 @@
         <source>Displays information about a person</source>
         <target state="translated">Zeigt die Informationen zu einer Person an</target>
       </trans-unit>
-      <trans-unit id="FMD.person.0">
+      <trans-unit id="FMD.persons.0">
         <source>Person</source>
         <target>Person</target>
       </trans-unit>
-      <trans-unit id="FMD.person.1" xml:space="preserve" approved="no">
+      <trans-unit id="FMD.persons.1" xml:space="preserve" approved="no">
         <source>Displays information about a person</source>
         <target state="translated">Zeigt die Informationen zu einer Person an</target>
       </trans-unit>

--- a/contao/languages/en/default.xlf
+++ b/contao/languages/en/default.xlf
@@ -7,10 +7,10 @@
       <trans-unit id="CTE.person.1">
         <source>Displays information about a person</source>
       </trans-unit>
-      <trans-unit id="FMD.person.0">
+      <trans-unit id="FMD.persons.0">
         <source>Person</source>
       </trans-unit>
-      <trans-unit id="FMD.person.1">
+      <trans-unit id="FMD.persons.1">
         <source>Displays information about a person</source>
       </trans-unit>
     </body>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes a typo in the id for the language files. Therefore the FE-Module does not have translations.

### Additional context


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Submit the PR against the `main` branch.
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).